### PR TITLE
Needed for x64 bash in x86 command prompt

### DIFF
--- a/CloneRepositories.cmd
+++ b/CloneRepositories.cmd
@@ -9,7 +9,10 @@ if not "%2"=="" set TYPE=%2
 set BASH="%PROGRAMFILES%\Git\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 
-set bash="%PROGRAMFILES(x86)%\Git\bin\bash.exe"
+set BASH="%PROGRAMFILES(x86)%\Git\bin\bash.exe"
+if exist %BASH% goto EXECUTE
+
+set BASH="%ProgramW6432%\Git\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 
 echo Failed to find bash.exe


### PR DESCRIPTION
CloneRepositories.cmd script fails to locate bash.exe in the following scenario:
64bit Windows OS
64bit Git for Windows Installed
System32 Command Prompt

This PR adds the environment variable check for ```%ProgramW6432%``` if the previous bash locations do not exist. This resolves the failed to find bash.exe message in the above scenario.