### PR TITLE
Use git bash from Scoop

### DIFF
--- a/CloneRepositories.cmd
+++ b/CloneRepositories.cmd
@@ -6,6 +6,9 @@ if not "%1"=="" set REPOS=%1
 set TYPE="full"
 if not "%2"=="" set TYPE=%2
 
+set BASH="%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
+if exist %BASH% goto EXECUTE
+
 set BASH="%PROGRAMFILES%\Git\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 

--- a/CloneRepositories.cmd
+++ b/CloneRepositories.cmd
@@ -6,9 +6,6 @@ if not "%1"=="" set REPOS=%1
 set TYPE="full"
 if not "%2"=="" set TYPE=%2
 
-set BASH="%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
-if exist %BASH% goto EXECUTE
-
 set BASH="%PROGRAMFILES%\Git\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 
@@ -16,6 +13,9 @@ set BASH="%PROGRAMFILES(x86)%\Git\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 
 set BASH="%ProgramW6432%\Git\bin\bash.exe"
+if exist %BASH% goto EXECUTE
+
+set BASH="%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
 if exist %BASH% goto EXECUTE
 
 echo Failed to find bash.exe


### PR DESCRIPTION
 - Scoop is a popular package manager for Windows (https://scoop.sh/)
 - Detects git installed with scoop and sets the path to this bash executable if present